### PR TITLE
Add nuspec for #3.

### DIFF
--- a/BarcodeLib/BarcodeLib.csproj
+++ b/BarcodeLib/BarcodeLib.csproj
@@ -110,7 +110,9 @@
     <Compile Include="Symbologies\UPCSupplement5.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Release Notes.txt" />
+    <None Include="Release Notes.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/BarcodeLib/BarcodeLib.nuspec
+++ b/BarcodeLib/BarcodeLib.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>https://github.com/bbarnhill/barcodelib/blob/$version$/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/bbarnhill/barcodelib</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/bbarnhill/barcodelib/$version$/BarcodeLibTest/Barcode.ico</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes></releaseNotes>
+    <copyright>Copyright © Brad Barnhill 2007-present</copyright>
+    <tags>barcode</tags>
+  </metadata>
+  <files>
+    <!--
+        Explicitly list files to distribute—and where. We want to
+        include the license in the binary distribution without copying
+        it into the source tree of the consuming project.
+    -->
+    <file src="..\LICENSE" target="lib\LICENSE"/>
+    <file src="Release Notes.txt" target="lib"/>
+  </files>
+</package>
+
+<!-- Please use nugetpack.cmd instead of invoking nuget pack directly.  -->
+$DoNotInvokeNugetPackDirectly$

--- a/BarcodeLib/nugetpack.cmd
+++ b/BarcodeLib/nugetpack.cmd
@@ -1,0 +1,25 @@
+@ECHO OFF
+
+WHERE /Q msbuild
+IF ERRORLEVEL 1 (
+    ECHO ERROR >&2
+    ECHO Please ensure that msbuild is in your path, perhaps by using >&2
+    ECHO the Developer Command Prompt feature of your Visual Studio >&2
+    ECHO installation. >&2
+    EXIT /B 1
+)
+
+WHERE /Q nuget
+IF ERRORLEVEL 1 (
+    ECHO ERROR >&2
+    ECHO Please install nuget.exe. You may obtain it from http://nuget.org/nuget.exe. >&2
+    ECHO You may copy nuget.exe to this folder or open an Administrator >&2
+    ECHO Command Prompt and COPY it to both %WINDIR%\system32 and >&2
+    ECHO %WINDIR%\syswow64 (the latter only if your Windows is multilib^). >&2
+    ECHO (Not using an elevated cmd session will result in the file ending >&2
+    ECHO up somewhere other than system32 or syswow64^). >&2
+    EXIT /B 1
+)
+
+SET CONFIGURATION_FLAG=Configuration=Release
+msbuild /p:%CONFIGURATION_FLAG% && nuget pack -Properties %CONFIGURATION_FLAG%;DoNotInvokeNugetPackDirectly=


### PR DESCRIPTION
I added a quirky nuspec which generates a nupkg in the way I think it should. The script, `nugetpack.cmd`, ensures that the assembly is built and packed from the correct build configuration. The nuspec makes the assumption that you will continue tagging releases using the same convention as you have so far (where the tag is just the version number (excluding the package name) and thereby links directly to the relevant LICENSE).

I also update .gitignore.

Hopefully things are straightforward enough or force you into (what in my opinion would be) the “pit of success”.